### PR TITLE
Modified instances and repositories to be independent from persistenc…

### DIFF
--- a/src/main/java/com/ub/higiea/application/domainservice/RouteService.java
+++ b/src/main/java/com/ub/higiea/application/domainservice/RouteService.java
@@ -25,12 +25,8 @@ public class RouteService {
     }
 
     public Mono<Route> createRoute(Truck truck, List<Sensor> sensors) {
-        return routeCalculator.calculateRoute(sensors) // Mono<List<Sensor>>
+        return routeCalculator.calculateRoute(sensors)
                 .flatMap(orderedSensors -> {
-                    List<Long> sensorIds = orderedSensors.stream()
-                            .map(Sensor::getId)
-                            .collect(Collectors.toList());
-
                     Mono<Double> totalDistanceMono = routeCalculator.calculateTotalDistance(orderedSensors);
                     Mono<Double> estimatedTimeMono = routeCalculator.calculateEstimatedTime(orderedSensors);
 
@@ -39,7 +35,7 @@ public class RouteService {
                                 Double totalDistance = tuple.getT1();
                                 Double estimatedTime = tuple.getT2();
 
-                                Route route = Route.create(truck.getId(), sensorIds, totalDistance, estimatedTime);
+                                Route route = Route.create(null, truck, orderedSensors, totalDistance, estimatedTime);
                                 return routeRepository.save(route);
                             });
                 });

--- a/src/main/java/com/ub/higiea/application/domainservice/SensorService.java
+++ b/src/main/java/com/ub/higiea/application/domainservice/SensorService.java
@@ -3,6 +3,7 @@ package com.ub.higiea.application.domainservice;
 import com.ub.higiea.application.dtos.SensorDTO;
 import com.ub.higiea.application.requests.SensorCreateRequest;
 import com.ub.higiea.domain.exception.notfound.SensorNotFoundException;
+import com.ub.higiea.domain.model.Location;
 import com.ub.higiea.domain.model.Sensor;
 import com.ub.higiea.domain.repository.SensorRepository;
 import org.springframework.stereotype.Service;
@@ -31,8 +32,8 @@ public class SensorService {
 
     public Mono<SensorDTO> createSensor(SensorCreateRequest request) {
         Sensor sensor = Sensor.create(
-                request.getLatitude(),
-                request.getLongitude(),
+                null,
+                Location.create(request.getLatitude(), request.getLongitude()),
                 request.getContainerState()
         );
         return sensorRepository.save(sensor)

--- a/src/main/java/com/ub/higiea/application/domainservice/TruckService.java
+++ b/src/main/java/com/ub/higiea/application/domainservice/TruckService.java
@@ -25,7 +25,7 @@ public class TruckService {
     }
 
     public Mono<TruckDTO> createTruck(TruckDTO truckDTO) {
-        Truck truck = Truck.create();
+        Truck truck = Truck.create(null);
         return truckRepository.save(truck)
                 .map(TruckDTO::fromTruck);
     }

--- a/src/main/java/com/ub/higiea/application/dtos/SensorDTO.java
+++ b/src/main/java/com/ub/higiea/application/dtos/SensorDTO.java
@@ -23,7 +23,7 @@ public class SensorDTO implements Serializable {
     public static SensorDTO fromSensor(Sensor sensor) {
         return new SensorDTO(
                 sensor.getId(),
-                new Point(sensor.getLatitude(),sensor.getLongitude()),
+                new Point(sensor.getLocation().getLatitude(),sensor.getLocation().getLongitude()),
                 sensor.getContainerState()
         );
     }

--- a/src/main/java/com/ub/higiea/domain/model/Location.java
+++ b/src/main/java/com/ub/higiea/domain/model/Location.java
@@ -1,0 +1,24 @@
+package com.ub.higiea.domain.model;
+
+public class Location {
+
+    double latitude;
+    double longitude;
+
+    private Location(double latitude, double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    public static Location create(double latitude, double longitude) {
+        return new Location(latitude, longitude);
+    }
+
+    public double getLatitude() {
+        return latitude;
+    }
+
+    public double getLongitude() {
+        return longitude;
+    }
+}

--- a/src/main/java/com/ub/higiea/domain/model/Route.java
+++ b/src/main/java/com/ub/higiea/domain/model/Route.java
@@ -1,54 +1,44 @@
 package com.ub.higiea.domain.model;
 
-import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.mapping.Document;
-import org.springframework.data.mongodb.core.mapping.Field;
-
 import java.util.List;
 
-@Document("route")
 public class Route {
 
-    @Id
     private String id;
 
-    @Field("truck_id")
-    private Long truckId;
+    private Truck truck;
 
-    @Field("sensor_ids")
-    private List<Long> sensorIds;
+    private List<Sensor> sensors;
 
-    @Field("distance")
     private Double totalDistance;
 
-    @Field("estimated_time")
     private Double estimatedTime;
 
     private Route() {
     }
 
-    private Route(Long truckId, List<Long> sensorIds, Double totalDistance, Double estimatedTime) {
-        this.truckId = truckId;
-        this.sensorIds = sensorIds;
+    private Route(String id, Truck truck, List<Sensor> sensors, Double totalDistance, Double estimatedTime) {
+        this.id = id;
+        this.truck = truck;
+        this.sensors = sensors;
         this.totalDistance = totalDistance;
         this.estimatedTime = estimatedTime;
     }
 
-    public static Route create(Long truckId, List<Long> sensorIds, Double totalDistance, Double estimatedTime) {
-        return new Route(truckId, sensorIds, totalDistance, estimatedTime);
+    public static Route create(String id, Truck truck, List<Sensor> sensors, Double totalDistance, Double estimatedTime) {
+        return new Route(id, truck, sensors, totalDistance, estimatedTime);
     }
-
 
     public String getId() {
         return id;
     }
 
-    public Long getTruckId() {
-        return truckId;
+    public Truck getTruck() {
+        return truck;
     }
 
-    public List<Long> getSensorIds() {
-        return sensorIds;
+    public List<Sensor> getSensors() {
+        return sensors;
     }
 
     public Double getTotalDistance() {

--- a/src/main/java/com/ub/higiea/domain/model/Sensor.java
+++ b/src/main/java/com/ub/higiea/domain/model/Sensor.java
@@ -1,57 +1,32 @@
 package com.ub.higiea.domain.model;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
-import org.springframework.data.annotation.Id;
-import org.springframework.data.relational.core.mapping.Column;
-import org.springframework.data.relational.core.mapping.Table;
-
-@Table("sensor")
 public class Sensor {
 
-    @Id
-    @Column("id")
     private Long id;
 
-    @NotNull
-    @Min(-90)
-    @Max(90)
-    @Column("latitude")
-    private Double latitude;
+    private Location location;
 
-    @NotNull
-    @Min(-180)
-    @Max(180)
-    @Column("longitude")
-    private Double longitude;
-
-    @Column("state")
     private ContainerState containerState;
 
     private Sensor() {
     }
 
-    private Sensor(Double latitude, Double longitude, ContainerState containerState) {
-        this.latitude = latitude;
-        this.longitude = longitude;
+    private Sensor(Long id, Location location, ContainerState containerState) {
+        this.id = id;
+        this.location = location;
         this.containerState = containerState;
     }
 
-    public static Sensor create(Double latitude, Double longitude, ContainerState containerState) {
-        return new Sensor(latitude, longitude, containerState);
+    public static Sensor create(Long id, Location location, ContainerState containerState) {
+        return new Sensor(id, location, containerState);
     }
 
     public Long getId() {
         return id;
     }
 
-    public Double getLatitude() {
-        return latitude;
-    }
-
-    public Double getLongitude() {
-        return longitude;
+    public Location getLocation() {
+        return location;
     }
 
     public ContainerState getContainerState() {

--- a/src/main/java/com/ub/higiea/domain/model/Truck.java
+++ b/src/main/java/com/ub/higiea/domain/model/Truck.java
@@ -1,21 +1,18 @@
 package com.ub.higiea.domain.model;
 
-import org.springframework.data.annotation.Id;
-import org.springframework.data.relational.core.mapping.Column;
-import org.springframework.data.relational.core.mapping.Table;
-
-@Table("truck")
 public class Truck {
 
-    @Id
-    @Column("id")
     private Long id;
 
     private Truck() {
     }
 
-    public static Truck create() {
-        return new Truck();
+    private Truck(Long id) {
+        this.id = id;
+    }
+
+    public static Truck create(Long id) {
+        return new Truck(id);
     }
 
     public Long getId() {

--- a/src/main/java/com/ub/higiea/domain/repository/RouteRepository.java
+++ b/src/main/java/com/ub/higiea/domain/repository/RouteRepository.java
@@ -1,7 +1,15 @@
 package com.ub.higiea.domain.repository;
 
 import com.ub.higiea.domain.model.Route;
-import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
-public interface RouteRepository extends ReactiveMongoRepository<Route, String> {
+public interface RouteRepository {
+
+    Mono<Route> findById(String id);
+
+    Flux<Route> findAll();
+
+    Mono<Route> save(Route route);
+
 }

--- a/src/main/java/com/ub/higiea/domain/repository/SensorRepository.java
+++ b/src/main/java/com/ub/higiea/domain/repository/SensorRepository.java
@@ -1,7 +1,15 @@
 package com.ub.higiea.domain.repository;
 
 import com.ub.higiea.domain.model.Sensor;
-import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
-public interface SensorRepository extends ReactiveCrudRepository<Sensor, Long> {
+public interface SensorRepository {
+
+    Mono<Sensor> findById(Long id);
+
+    Flux<Sensor> findAll();
+
+    Mono<Sensor> save(Sensor sensor);
+
 }

--- a/src/main/java/com/ub/higiea/domain/repository/TruckRepository.java
+++ b/src/main/java/com/ub/higiea/domain/repository/TruckRepository.java
@@ -1,7 +1,15 @@
 package com.ub.higiea.domain.repository;
 
 import com.ub.higiea.domain.model.Truck;
-import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
-public interface TruckRepository extends ReactiveCrudRepository<Truck, Long> {
+public interface TruckRepository {
+
+    Mono<Truck> findById(Long id);
+
+    Flux<Truck> findAll();
+
+    Mono<Truck> save(Truck truck);
+
 }

--- a/src/main/java/com/ub/higiea/infrastructure/persistence/entities/RouteEntity.java
+++ b/src/main/java/com/ub/higiea/infrastructure/persistence/entities/RouteEntity.java
@@ -1,0 +1,61 @@
+package com.ub.higiea.infrastructure.persistence.entities;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+import java.util.List;
+
+@Document("route")
+public class RouteEntity {
+
+    @Id
+    private ObjectId id;
+
+    @Field("truck_id")
+    private Long truckId;
+
+    @Field("sensor_ids")
+    private List<Long> sensorIds;
+
+    @Field("distance")
+    private Double totalDistance;
+
+    @Field("estimated_time")
+    private Double estimatedTime;
+
+    public RouteEntity() {
+    }
+
+    public RouteEntity(ObjectId id, Long truckId, List<Long> sensorIds, Double totalDistance, Double estimatedTime) {
+        this.id = id;
+        this.truckId = truckId;
+        this.sensorIds = sensorIds;
+        this.totalDistance = totalDistance;
+        this.estimatedTime = estimatedTime;
+    }
+
+    public ObjectId getId() {
+        return id;
+    }
+
+    public void setId(ObjectId id) {
+        this.id = id;
+    }
+
+    public Long getTruckId() {
+        return truckId;
+    }
+
+    public List<Long> getSensorIds() {
+        return sensorIds;
+    }
+
+    public Double getTotalDistance() {
+        return totalDistance;
+    }
+
+    public Double getEstimatedTime() {
+        return estimatedTime;
+    }
+}

--- a/src/main/java/com/ub/higiea/infrastructure/persistence/entities/SensorEntity.java
+++ b/src/main/java/com/ub/higiea/infrastructure/persistence/entities/SensorEntity.java
@@ -1,0 +1,51 @@
+package com.ub.higiea.infrastructure.persistence.entities;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+import org.springframework.data.relational.core.mapping.Column;
+
+@Table("sensor")
+public class SensorEntity {
+
+    @Id
+    private Long id;
+
+    @Column("latitude")
+    private Double latitude;
+
+    @Column("longitude")
+    private Double longitude;
+
+    @Column("state")
+    private String containerState;
+
+    public SensorEntity() {
+    }
+
+    public SensorEntity(Double latitude, Double longitude, String containerState) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.containerState = containerState;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Double getLatitude() {
+        return latitude;
+    }
+
+    public Double getLongitude() {
+        return longitude;
+    }
+
+    public String getContainerState() {
+        return containerState;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+}

--- a/src/main/java/com/ub/higiea/infrastructure/persistence/entities/TruckEntity.java
+++ b/src/main/java/com/ub/higiea/infrastructure/persistence/entities/TruckEntity.java
@@ -1,0 +1,23 @@
+package com.ub.higiea.infrastructure.persistence.entities;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table("truck")
+public class TruckEntity {
+
+    @Id
+    private Long id;
+
+    public TruckEntity() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+}

--- a/src/main/java/com/ub/higiea/infrastructure/persistence/mapper/RouteMapper.java
+++ b/src/main/java/com/ub/higiea/infrastructure/persistence/mapper/RouteMapper.java
@@ -1,0 +1,40 @@
+package com.ub.higiea.infrastructure.persistence.mapper;
+
+import com.ub.higiea.domain.model.Route;
+import com.ub.higiea.domain.model.Sensor;
+import com.ub.higiea.domain.model.Truck;
+import com.ub.higiea.infrastructure.persistence.entities.RouteEntity;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RouteMapper {
+
+    public static Route toDomain(RouteEntity entity, Truck truck, List<Sensor> sensors) {
+        return Route.create(
+                entity.getId().toHexString(),
+                truck,
+                sensors,
+                entity.getTotalDistance(),
+                entity.getEstimatedTime()
+        );
+    }
+
+    public static RouteEntity toEntity(Route route) {
+        List<Long> sensorIds = route.getSensors().stream()
+                .map(Sensor::getId)
+                .collect(Collectors.toList());
+
+        ObjectId objectId = route.getId() != null ? new ObjectId(route.getId()) : null;
+
+        return new RouteEntity(
+                objectId,
+                route.getTruck().getId(),
+                sensorIds,
+                route.getTotalDistance(),
+                route.getEstimatedTime()
+        );
+    }
+
+}

--- a/src/main/java/com/ub/higiea/infrastructure/persistence/mapper/SensorMapper.java
+++ b/src/main/java/com/ub/higiea/infrastructure/persistence/mapper/SensorMapper.java
@@ -1,0 +1,29 @@
+package com.ub.higiea.infrastructure.persistence.mapper;
+
+import com.ub.higiea.domain.model.ContainerState;
+import com.ub.higiea.domain.model.Location;
+import com.ub.higiea.domain.model.Sensor;
+import com.ub.higiea.infrastructure.persistence.entities.SensorEntity;
+
+public class SensorMapper {
+
+    public static Sensor toDomain(SensorEntity entity) {
+        Location location = Location.create(entity.getLatitude(), entity.getLongitude());
+        ContainerState containerState = ContainerState.valueOf(entity.getContainerState());
+
+        return Sensor.create(entity.getId(), location, containerState);
+    }
+
+    public static SensorEntity toEntity(Sensor sensor) {
+        SensorEntity entity = new SensorEntity(
+                sensor.getLocation().getLatitude(),
+                sensor.getLocation().getLongitude(),
+                sensor.getContainerState().name()
+        );
+        if (sensor.getId() != null) {
+            entity.setId(sensor.getId());
+        }
+        return entity;
+    }
+
+}

--- a/src/main/java/com/ub/higiea/infrastructure/persistence/mapper/TruckMapper.java
+++ b/src/main/java/com/ub/higiea/infrastructure/persistence/mapper/TruckMapper.java
@@ -1,0 +1,20 @@
+package com.ub.higiea.infrastructure.persistence.mapper;
+
+import com.ub.higiea.domain.model.Truck;
+import com.ub.higiea.infrastructure.persistence.entities.TruckEntity;
+
+public class TruckMapper {
+
+    public static Truck toDomain(TruckEntity truckEntity) {
+        return Truck.create(truckEntity.getId());
+    }
+
+    public static TruckEntity toEntity(Truck truck) {
+        TruckEntity entity = new TruckEntity();
+        if (truck.getId() != null) {
+            entity.setId(truck.getId());
+        }
+        return entity;
+    }
+
+}

--- a/src/main/java/com/ub/higiea/infrastructure/persistence/repositories/RouteEntityRepository.java
+++ b/src/main/java/com/ub/higiea/infrastructure/persistence/repositories/RouteEntityRepository.java
@@ -1,0 +1,9 @@
+package com.ub.higiea.infrastructure.persistence.repositories;
+
+import com.ub.higiea.infrastructure.persistence.entities.RouteEntity;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+
+public interface RouteEntityRepository extends ReactiveMongoRepository <RouteEntity, ObjectId> {
+
+}

--- a/src/main/java/com/ub/higiea/infrastructure/persistence/repositories/RouteRepositoryImpl.java
+++ b/src/main/java/com/ub/higiea/infrastructure/persistence/repositories/RouteRepositoryImpl.java
@@ -1,0 +1,77 @@
+package com.ub.higiea.infrastructure.persistence.repositories;
+
+import com.ub.higiea.domain.model.Route;
+import com.ub.higiea.domain.model.Truck;
+import com.ub.higiea.domain.model.Sensor;
+import com.ub.higiea.domain.repository.RouteRepository;
+import com.ub.higiea.domain.repository.SensorRepository;
+import com.ub.higiea.domain.repository.TruckRepository;
+import com.ub.higiea.infrastructure.persistence.entities.RouteEntity;
+import com.ub.higiea.infrastructure.persistence.mapper.RouteMapper;
+import org.bson.types.ObjectId;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Repository
+public class RouteRepositoryImpl implements RouteRepository {
+
+    private final RouteEntityRepository routeEntityRepository;
+    private final TruckRepository truckRepository;
+    private final SensorRepository sensorRepository;
+
+    public RouteRepositoryImpl(RouteEntityRepository routeEntityRepository,
+                               TruckRepository truckRepository,
+                               SensorRepository sensorRepository) {
+
+        this.routeEntityRepository = routeEntityRepository;
+        this.truckRepository = truckRepository;
+        this.sensorRepository = sensorRepository;
+    }
+
+    @Override
+    public Mono<Route> findById(String id) {
+        return routeEntityRepository.findById(new ObjectId(id))
+                .flatMap(entity ->
+                        Mono.zip(
+                                truckRepository.findById(entity.getTruckId()),
+                                Flux.fromIterable(entity.getSensorIds())
+                                        .flatMap(sensorRepository::findById)
+                                        .collectList(),
+                                (truck, sensors) -> RouteMapper.toDomain(entity, truck, sensors)
+                        )
+                );
+    }
+
+    @Override
+    public Flux<Route> findAll() {
+        return routeEntityRepository.findAll()
+                .flatMap(entity ->
+                        Mono.zip(
+                                truckRepository.findById(entity.getTruckId()),
+                                Flux.fromIterable(entity.getSensorIds())
+                                        .flatMap(sensorRepository::findById)
+                                        .collectList(),
+                                (truck, sensors) -> RouteMapper.toDomain(entity, truck, sensors)
+                        )
+                );
+    }
+
+    @Override
+    public Mono<Route> save(Route route) {
+        RouteEntity entity = RouteMapper.toEntity(route);
+        return routeEntityRepository.save(entity)
+                .flatMap(savedEntity ->
+                        Mono.zip(
+                                truckRepository.findById(savedEntity.getTruckId()),
+                                Flux.fromIterable(savedEntity.getSensorIds())
+                                        .flatMap(sensorRepository::findById)
+                                        .collectList(),
+                                (truck, sensors) -> RouteMapper.toDomain(savedEntity, truck, sensors)
+                        )
+                );
+    }
+
+}

--- a/src/main/java/com/ub/higiea/infrastructure/persistence/repositories/SensorEntityRepository.java
+++ b/src/main/java/com/ub/higiea/infrastructure/persistence/repositories/SensorEntityRepository.java
@@ -1,0 +1,8 @@
+package com.ub.higiea.infrastructure.persistence.repositories;
+
+import com.ub.higiea.infrastructure.persistence.entities.SensorEntity;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+public interface SensorEntityRepository extends ReactiveCrudRepository<SensorEntity, Long> {
+
+}

--- a/src/main/java/com/ub/higiea/infrastructure/persistence/repositories/SensorRespositoryImpl.java
+++ b/src/main/java/com/ub/higiea/infrastructure/persistence/repositories/SensorRespositoryImpl.java
@@ -1,0 +1,40 @@
+package com.ub.higiea.infrastructure.persistence.repositories;
+
+import com.ub.higiea.domain.model.Sensor;
+import com.ub.higiea.domain.repository.SensorRepository;
+import com.ub.higiea.infrastructure.persistence.entities.SensorEntity;
+import com.ub.higiea.infrastructure.persistence.mapper.SensorMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Repository
+public class SensorRespositoryImpl implements SensorRepository {
+
+    private final SensorEntityRepository sensorEntityRepository;
+
+    public SensorRespositoryImpl(SensorEntityRepository sensorEntityRepository) {
+        this.sensorEntityRepository = sensorEntityRepository;
+    }
+
+    @Override
+    public Mono<Sensor> findById(Long id) {
+        return sensorEntityRepository.findById(id)
+                .map(SensorMapper::toDomain);
+    }
+
+    @Override
+    public Flux<Sensor> findAll() {
+        return sensorEntityRepository.findAll()
+                .map(SensorMapper::toDomain);
+    }
+
+    @Override
+    public Mono<Sensor> save(Sensor sensor) {
+        SensorEntity entity = SensorMapper.toEntity(sensor);
+        return sensorEntityRepository.save(entity)
+                .map(SensorMapper::toDomain);
+    }
+
+}

--- a/src/main/java/com/ub/higiea/infrastructure/persistence/repositories/TruckEntityRepository.java
+++ b/src/main/java/com/ub/higiea/infrastructure/persistence/repositories/TruckEntityRepository.java
@@ -1,0 +1,8 @@
+package com.ub.higiea.infrastructure.persistence.repositories;
+
+import com.ub.higiea.infrastructure.persistence.entities.TruckEntity;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+public interface TruckEntityRepository extends ReactiveCrudRepository<TruckEntity, Long> {
+
+}

--- a/src/main/java/com/ub/higiea/infrastructure/persistence/repositories/TruckRepositoryImpl.java
+++ b/src/main/java/com/ub/higiea/infrastructure/persistence/repositories/TruckRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.ub.higiea.infrastructure.persistence.repositories;
+
+import com.ub.higiea.domain.model.Truck;
+import com.ub.higiea.domain.repository.TruckRepository;
+import com.ub.higiea.infrastructure.persistence.entities.TruckEntity;
+import com.ub.higiea.infrastructure.persistence.mapper.TruckMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Repository
+public class TruckRepositoryImpl implements TruckRepository {
+
+    private final TruckEntityRepository truckEntityRepository;
+
+    public TruckRepositoryImpl(TruckEntityRepository truckEntityRepository) {
+        this.truckEntityRepository = truckEntityRepository;
+    }
+
+    @Override
+    public Mono<Truck> findById(Long id) {
+        return truckEntityRepository.findById(id)
+                .map(TruckMapper::toDomain);
+    }
+
+    @Override
+    public Flux<Truck> findAll() {
+        return truckEntityRepository.findAll()
+                .map(TruckMapper::toDomain);
+    }
+
+    @Override
+    public Mono<Truck> save(Truck truck) {
+        TruckEntity entity = TruckMapper.toEntity(truck);
+        return truckEntityRepository.save(entity)
+                .map(TruckMapper::toDomain);
+    }
+
+}

--- a/src/test/java/com/ub/higiea/application/domainservice/RouteServiceTest.java
+++ b/src/test/java/com/ub/higiea/application/domainservice/RouteServiceTest.java
@@ -1,10 +1,7 @@
 package com.ub.higiea.application.domainservice;
 
 import com.ub.higiea.application.utils.RouteCalculator;
-import com.ub.higiea.domain.model.ContainerState;
-import com.ub.higiea.domain.model.Route;
-import com.ub.higiea.domain.model.Sensor;
-import com.ub.higiea.domain.model.Truck;
+import com.ub.higiea.domain.model.*;
 import com.ub.higiea.domain.repository.RouteRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,13 +27,10 @@ public class RouteServiceTest {
     @Test
     void createRoute_shouldSaveRoute_WhenValidInput() {
 
-        Truck truck = Truck.create();
-        ReflectionTestUtils.setField(truck, "id", 1L);
+        Truck truck = Truck.create(1L);
 
-        Sensor sensor1 = Sensor.create(20.0,15.0, ContainerState.FULL);
-        Sensor sensor2 = Sensor.create(30.0,15.0, ContainerState.FULL);
-        ReflectionTestUtils.setField(sensor1, "id", 1L);
-        ReflectionTestUtils.setField(sensor2, "id", 2L);
+        Sensor sensor1 = Sensor.create(1L,Location.create(20.0,15.0), ContainerState.FULL);
+        Sensor sensor2 = Sensor.create(2L, Location.create(30.0,15.0), ContainerState.FULL);
 
         List<Sensor> sensors = List.of(sensor1,sensor2);
         List<Sensor> orderedSensors = List.of(sensor1,sensor2);
@@ -45,14 +39,14 @@ public class RouteServiceTest {
         Mockito.when(routeCalculator.calculateTotalDistance(orderedSensors)).thenReturn(Mono.just(30.0));
         Mockito.when(routeCalculator.calculateEstimatedTime(orderedSensors)).thenReturn(Mono.just(45.0));
 
-        Route expectedRoute = Route.create(truck.getId(), List.of(sensor1.getId(), sensor2.getId()), 30.0, 45.0);
+        Route expectedRoute = Route.create("1",truck, List.of(sensor1, sensor2), 30.0, 45.0);
         Mockito.when(routeRepository.save(Mockito.any(Route.class))).thenReturn(Mono.just(expectedRoute));
 
         Mono<Route> result = routeService.createRoute(truck, sensors);
         StepVerifier.create(result)
                 .expectNextMatches(route ->
-                        route.getTruckId().equals(truck.getId()) &&
-                                route.getSensorIds().equals(List.of(sensor1.getId(), sensor2.getId())) &&
+                        route.getTruck().equals(truck) &&
+                                route.getSensors().equals(List.of(sensor1, sensor2)) &&
                                 route.getTotalDistance().equals(30.0) &&
                                 route.getEstimatedTime().equals(45.0)
                 )

--- a/src/test/java/com/ub/higiea/application/domainservice/SensorServiceTest.java
+++ b/src/test/java/com/ub/higiea/application/domainservice/SensorServiceTest.java
@@ -4,6 +4,7 @@ import com.ub.higiea.application.dtos.SensorDTO;
 import com.ub.higiea.application.requests.SensorCreateRequest;
 import com.ub.higiea.domain.exception.notfound.SensorNotFoundException;
 import com.ub.higiea.domain.model.ContainerState;
+import com.ub.higiea.domain.model.Location;
 import com.ub.higiea.domain.model.Sensor;
 import com.ub.higiea.domain.repository.SensorRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,8 +29,8 @@ public class SensorServiceTest {
 
     @Test
     void getAllSensors_ShouldReturnAllSensorsDTOs_WhenRepositoryNotEmpty() {
-        Sensor sensor1 = Sensor.create(20.0, 10.0, ContainerState.EMPTY);
-        Sensor sensor2 = Sensor.create(25.0, 15.0, ContainerState.FULL);
+        Sensor sensor1 = Sensor.create(1L, Location.create(20.0, 10.0), ContainerState.EMPTY);
+        Sensor sensor2 = Sensor.create(2L, Location.create(30.0, 20.0), ContainerState.FULL);
 
         SensorDTO expectedSensor1DTO = SensorDTO.fromSensor(sensor1);
         SensorDTO expectedSensor2DTO = SensorDTO.fromSensor(sensor2);
@@ -37,8 +38,8 @@ public class SensorServiceTest {
         Mockito.when(sensorRepository.findAll()).thenReturn(Flux.just(sensor1, sensor2));
 
         StepVerifier.create(sensorService.getAllSensors())
-                .expectNextMatches(dto -> dto.equals(expectedSensor1DTO))  // Check properties of first SensorDTO
-                .expectNextMatches(dto -> dto.equals(expectedSensor2DTO))  // Check properties of second SensorDTO
+                .expectNextMatches(dto -> dto.equals(expectedSensor1DTO))
+                .expectNextMatches(dto -> dto.equals(expectedSensor2DTO))
                 .verifyComplete();
     }
 
@@ -52,14 +53,13 @@ public class SensorServiceTest {
 
     @Test
     void getSensorById_shouldReturnSensorDTO_WhenSensorFound() {
-        Sensor sensor = Sensor.create(20.0, 10.0, ContainerState.EMPTY);
-        ReflectionTestUtils.setField(sensor, "id", 1L);
+        Sensor sensor = Sensor.create(1L, Location.create(20.0, 10.0), ContainerState.EMPTY);
         SensorDTO expectedSensorDTO = SensorDTO.fromSensor(sensor);
 
         Mockito.when(sensorRepository.findById(sensor.getId())).thenReturn(Mono.just(sensor));
 
         StepVerifier.create(sensorService.getSensorById(sensor.getId()))
-                .expectNextMatches(dto -> dto.equals(expectedSensorDTO))  // Verify properties of SensorDTO
+                .expectNextMatches(dto -> dto.equals(expectedSensorDTO))
                 .verifyComplete();
     }
 
@@ -79,8 +79,7 @@ public class SensorServiceTest {
                 10.0, 20.0,
                 ContainerState.EMPTY
         );
-        Sensor sensor = Sensor.create(10.0, 20.0, ContainerState.EMPTY);
-        ReflectionTestUtils.setField(sensor, "id", 1L); // Set ID for testing
+        Sensor sensor = Sensor.create(1L, Location.create(20.0, 10.0), ContainerState.EMPTY);
 
         SensorDTO expectedSensorDTO = SensorDTO.fromSensor(sensor);
 

--- a/src/test/java/com/ub/higiea/infrastructure/controller/SensorControllerTest.java
+++ b/src/test/java/com/ub/higiea/infrastructure/controller/SensorControllerTest.java
@@ -5,6 +5,7 @@ import com.ub.higiea.application.domainservice.SensorService;
 import com.ub.higiea.application.requests.SensorCreateRequest;
 import com.ub.higiea.domain.exception.notfound.SensorNotFoundException;
 import com.ub.higiea.domain.model.ContainerState;
+import com.ub.higiea.domain.model.Location;
 import com.ub.higiea.domain.model.Sensor;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -29,10 +30,8 @@ public class SensorControllerTest {
     @Test
     void getAllSensors_ShouldReturnListOfSensorDTOs() {
 
-        Sensor sensor1 = Sensor.create(10.0, 20.0, ContainerState.EMPTY);
-        ReflectionTestUtils.setField(sensor1, "id", 1L);
-        Sensor sensor2 = Sensor.create(10.0, 20.0, ContainerState.EMPTY);
-        ReflectionTestUtils.setField(sensor2, "id", 2L);
+        Sensor sensor1 = Sensor.create(1L, Location.create(20.0, 10.0), ContainerState.EMPTY);
+        Sensor sensor2 = Sensor.create(2L, Location.create(30.0, 60.0), ContainerState.EMPTY);
 
        SensorDTO sensorDTO1 = SensorDTO.fromSensor(sensor1);
        SensorDTO sensorDTO2 = SensorDTO.fromSensor(sensor2);
@@ -51,8 +50,7 @@ public class SensorControllerTest {
     @Test
     void getSensorById_ShouldReturnSensorDTO_WhenSensorExists() {
 
-        Sensor sensor = Sensor.create(10.0, 20.0, ContainerState.EMPTY);
-        ReflectionTestUtils.setField(sensor, "id", 1L);
+        Sensor sensor = Sensor.create(1L, Location.create(20.0, 10.0), ContainerState.EMPTY);
 
         SensorDTO expectedSensorDTO = SensorDTO.fromSensor(sensor);
 
@@ -75,8 +73,7 @@ public class SensorControllerTest {
                 20.0,
                 ContainerState.EMPTY
         );
-        Sensor sensor = Sensor.create(10.0, 20.0, ContainerState.EMPTY);
-        ReflectionTestUtils.setField(sensor, "id", 1L);
+        Sensor sensor = Sensor.create(1L, Location.create(20.0, 10.0), ContainerState.EMPTY);
         SensorDTO sensorDTO = SensorDTO.fromSensor(sensor);
 
         Mockito.when(sensorService.createSensor(Mockito.argThat(request ->


### PR DESCRIPTION
I have modified Sensor, Truck and Route entity in order decouple them from the Persistence layer. For example, the annotations (Column, Table,...) have been removed. I have implemented in the infrastructure layer all the database entities and mappers

I have also modified the Repositories to decouple from external libraries/reactive programming. Avoiding the use of ReactiveRepository. I have implemented each repository in the infrastructure layer 